### PR TITLE
Add geometry length scaling to DagMC

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -13,6 +13,7 @@ Next version
 
 **Added:**
   * Allow download & build of MOAB from cmake at build time (#969)
+  * Add a pre-load length multiplier for DAGMC geometry.
 
 **Fixed**
   * Fixed HDF5 naming convention for docker container building and naming (#976)

--- a/src/dagmc/DagMC.cpp
+++ b/src/dagmc/DagMC.cpp
@@ -9,12 +9,15 @@
 #include <algorithm>
 #include <array>
 #include <climits>
+#include <cmath>
 #include <fstream>
 #include <iostream>
 #include <limits>
 #include <set>
 #include <sstream>
+#include <stdexcept>
 #include <string>
+#include <vector>
 
 #ifdef DOUBLE_DOWN
 #include "double_down/RTI.hpp"
@@ -27,6 +30,7 @@
 
 #define MB_OBB_TREE_TAG_NAME "OBB_TREE"
 #define FACETING_TOL_TAG_NAME "FACETING_TOL"
+#define GEOMETRY_RESABS_TAG_NAME "GEOMETRY_RESABS"
 static const int null_delimiter_length = 1;
 
 namespace moab {
@@ -95,6 +99,16 @@ DagMC::DagMC(Interface* mb_impl, double overlap_tolerance,
   this->set_numerical_precision(p_numerical_precision);
 }
 
+void DagMC::set_length_multiplier(double multiplier) {
+  if (!std::isfinite(multiplier) || multiplier <= 0.0)
+    throw std::invalid_argument(
+        "Length multiplier must be positive and finite.");
+  if (lengthMultiplierLocked)
+    throw std::logic_error(
+        "Length multiplier cannot be changed after loading.");
+  lengthMultiplier = multiplier;
+}
+
 // Destructor
 DagMC::~DagMC() {
   // if we created the moab instance
@@ -116,6 +130,10 @@ float DagMC::version(std::string* version_string) {
 
 // the standard DAGMC load file method
 ErrorCode DagMC::load_file(const char* cfile) {
+  if (lengthMultiplier != 1.0 && lengthMultiplierLocked) {
+    MB_SET_ERR(MB_FAILURE, "Length scaling has already been applied.");
+  }
+
   ErrorCode rval;
   std::string filename(cfile);
   std::stringstream ss;
@@ -155,11 +173,152 @@ ErrorCode DagMC::load_file(const char* cfile) {
     return rval;
   }
 
-  return finish_loading();
+  rval = apply_length_scale(file_set);
+  MB_CHK_SET_ERR(rval, "Failed to scale geometry.");
+
+  rval = finish_loading();
+  if (MB_SUCCESS == rval) {
+    lengthMultiplierLocked = true;
+  }
+  return rval;
 }
 
 // helper function to load the existing contents of a MOAB instance into DAGMC
-ErrorCode DagMC::load_existing_contents() { return finish_loading(); }
+ErrorCode DagMC::load_existing_contents() {
+  if (lengthMultiplier != 1.0 && lengthMultiplierLocked) {
+    MB_SET_ERR(MB_FAILURE, "Length scaling has already been applied.");
+  }
+
+  ErrorCode rval = apply_length_scale(0);
+  MB_CHK_SET_ERR(rval, "Failed to scale geometry.");
+
+  rval = finish_loading();
+  if (MB_SUCCESS == rval) {
+    lengthMultiplierLocked = true;
+  }
+  return rval;
+}
+
+ErrorCode DagMC::apply_length_scale(EntityHandle entity_set) {
+  if (lengthMultiplier == 1.0) return MB_SUCCESS;
+
+  GeomTopoTool scaled_geometry(MBI, false, entity_set);
+  ErrorCode rval = scaled_geometry.find_geomsets();
+  MB_CHK_SET_ERR(rval, "Failed to find geometry sets.");
+
+  Range surfaces, volumes;
+  rval = scaled_geometry.get_gsets_by_dimension(2, surfaces);
+  MB_CHK_SET_ERR(rval, "Failed to retrieve geometry surfaces.");
+  rval = scaled_geometry.get_gsets_by_dimension(3, volumes);
+  MB_CHK_SET_ERR(rval, "Failed to retrieve geometry volumes.");
+
+  Range triangles;
+  for (EntityHandle surface : surfaces) {
+    rval = MBI->get_entities_by_type(surface, MBTRI, triangles, true);
+    MB_CHK_SET_ERR(rval, "Failed to retrieve geometry triangles.");
+  }
+
+  Range vertices;
+  rval = MBI->get_adjacencies(triangles, 0, false, vertices, Interface::UNION);
+  MB_CHK_SET_ERR(rval, "Failed to retrieve geometry vertices.");
+
+  std::vector<double> coords(3 * vertices.size());
+  rval = MBI->get_coords(vertices, coords.data());
+  MB_CHK_SET_ERR(rval, "Failed to retrieve vertex coordinates.");
+  for (double& value : coords) value *= lengthMultiplier;
+
+  lengthMultiplierLocked = true;
+  rval = delete_obb_trees(entity_set, surfaces, volumes);
+  MB_CHK_SET_ERR(rval, "Failed to delete stale OBB trees.");
+
+  rval = MBI->set_coords(vertices, coords.data());
+  MB_CHK_SET_ERR(rval, "Failed to update vertex coordinates.");
+  return scale_length_metadata(entity_set, surfaces, volumes);
+}
+
+ErrorCode DagMC::scale_length_metadata(EntityHandle entity_set,
+                                       const Range& surfaces,
+                                       const Range& volumes) {
+  Range geometry_sets = surfaces;
+  geometry_sets.merge(volumes);
+
+  const char* tag_names[] = {FACETING_TOL_TAG_NAME, GEOMETRY_RESABS_TAG_NAME};
+  for (const char* tag_name : tag_names) {
+    Tag tag;
+    ErrorCode rval = MBI->tag_get_handle(tag_name, tag);
+    if (rval == MB_TAG_NOT_FOUND) continue;
+    MB_CHK_SET_ERR(rval, "Failed to retrieve length metadata.");
+
+    Range tagged_sets;
+    rval = MBI->get_entities_by_type_and_tag(0, MBENTITYSET, &tag, NULL, 1,
+                                             tagged_sets);
+    MB_CHK_SET_ERR(rval, "Failed to find length metadata.");
+
+    Range geometry_metadata;
+    for (EntityHandle tagged_set : tagged_sets) {
+      Range contained_sets;
+      rval = MBI->get_entities_by_type(tagged_set, MBENTITYSET, contained_sets,
+                                       true);
+      MB_CHK_SET_ERR(rval, "Failed to inspect length metadata.");
+      if (geometry_sets.find(tagged_set) != geometry_sets.end() ||
+          !intersect(contained_sets, geometry_sets).empty())
+        geometry_metadata.insert(tagged_set);
+    }
+
+    if (!geometry_metadata.empty()) {
+      std::vector<double> values(geometry_metadata.size());
+      rval = MBI->tag_get_data(tag, geometry_metadata, values.data());
+      MB_CHK_SET_ERR(rval, "Failed to read length metadata.");
+      for (double& value : values) value *= lengthMultiplier;
+      rval = MBI->tag_set_data(tag, geometry_metadata, values.data());
+      MB_CHK_SET_ERR(rval, "Failed to scale length metadata.");
+    }
+
+    if (entity_set == 0) {
+      const EntityHandle root = 0;
+      double value;
+      rval = MBI->tag_get_data(tag, &root, 1, &value);
+      if (rval == MB_SUCCESS) {
+        value *= lengthMultiplier;
+        rval = MBI->tag_set_data(tag, &root, 1, &value);
+        MB_CHK_SET_ERR(rval, "Failed to scale root length metadata.");
+      } else if (rval != MB_TAG_NOT_FOUND)
+        MB_CHK_SET_ERR(rval, "Failed to read root length metadata.");
+    }
+  }
+  return MB_SUCCESS;
+}
+
+ErrorCode DagMC::delete_obb_trees(EntityHandle entity_set,
+                                  const Range& surfaces, const Range& volumes) {
+  Tag root_tag;
+  ErrorCode rval = MBI->tag_get_handle("OBB_ROOT", root_tag);
+  if (rval == MB_TAG_NOT_FOUND) return MB_SUCCESS;
+  MB_CHK_SET_ERR(rval, "Failed to retrieve the OBB root tag.");
+
+  Range geometry_sets = surfaces;
+  geometry_sets.merge(volumes);
+  Range tree_nodes;
+  for (EntityHandle geometry_set : geometry_sets) {
+    EntityHandle root;
+    rval = MBI->tag_get_data(root_tag, &geometry_set, 1, &root);
+    if (rval == MB_TAG_NOT_FOUND) continue;
+    MB_CHK_SET_ERR(rval, "Failed to retrieve an OBB root.");
+
+    tree_nodes.insert(root);
+    Range descendants;
+    rval = MBI->get_child_meshsets(root, descendants, 0);
+    MB_CHK_SET_ERR(rval, "Failed to retrieve OBB tree nodes.");
+    tree_nodes.merge(descendants);
+
+    rval = MBI->tag_delete_data(root_tag, &geometry_set, 1);
+    MB_CHK_SET_ERR(rval, "Failed to clear an OBB root.");
+  }
+
+  if (entity_set != 0) tree_nodes.erase(entity_set);
+  if (tree_nodes.empty()) return MB_SUCCESS;
+  return MBI->delete_entities(tree_nodes);
+}
 
 // setup the implicit compliment
 ErrorCode DagMC::setup_impl_compl() {

--- a/src/dagmc/DagMC.hpp
+++ b/src/dagmc/DagMC.hpp
@@ -128,6 +128,11 @@ class DagMC {
    */
   ErrorCode load_existing_contents();
 
+  //! Set the finite, positive scale applied when geometry is loaded.
+  void set_length_multiplier(double multiplier);
+
+  double length_multiplier() const { return lengthMultiplier; }
+
   /**\brief initializes the geometry and OBB tree structure for ray firing
    * acceleration
    *
@@ -203,6 +208,14 @@ class DagMC {
 
   /** loading code shared by load_file and load_existing_contents */
   ErrorCode finish_loading();
+
+  ErrorCode apply_length_scale(EntityHandle entity_set);
+
+  ErrorCode scale_length_metadata(EntityHandle entity_set,
+                                  const Range& surfaces, const Range& volumes);
+
+  ErrorCode delete_obb_trees(EntityHandle entity_set, const Range& surfaces,
+                             const Range& volumes);
 
   /* SECTION II: Fundamental Geometry Operations/Queries */
  public:
@@ -706,6 +719,8 @@ class DagMC {
   char implComplName[NAME_TAG_SIZE];
 
   double facetingTolerance;
+  double lengthMultiplier = 1.0;
+  bool lengthMultiplierLocked = false;
 
   /** vectors for point_in_volume: */
   std::vector<double> disList;

--- a/src/dagmc/tests/dagmc_simple_test.cpp
+++ b/src/dagmc/tests/dagmc_simple_test.cpp
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 
 #include <iostream>
+#include <limits>
+#include <vector>
 
 #include "DagMC.hpp"
 #include "moab/Core.hpp"
@@ -13,6 +15,49 @@ using moab::DagMC;
 moab::DagMC* DAG;
 
 static const char input_file[] = "test_geom.h5m";
+
+static Range geometry_vertices(DagMC& dagmc) {
+  Range surfaces, triangles, vertices;
+  EXPECT_EQ(dagmc.geom_tool()->get_gsets_by_dimension(2, surfaces), MB_SUCCESS);
+  for (EntityHandle surface : surfaces)
+    EXPECT_EQ(dagmc.moab_instance()->get_entities_by_type(surface, MBTRI,
+                                                          triangles, true),
+              MB_SUCCESS);
+  EXPECT_EQ(dagmc.moab_instance()->get_adjacencies(triangles, 0, false,
+                                                   vertices, Interface::UNION),
+            MB_SUCCESS);
+  EXPECT_LT(vertices.size(), 3 * triangles.size());
+  return vertices;
+}
+
+static std::vector<double> geometry_coordinates(DagMC& dagmc) {
+  Range vertices = geometry_vertices(dagmc);
+  std::vector<double> coordinates(3 * vertices.size());
+  EXPECT_EQ(dagmc.moab_instance()->get_coords(vertices, coordinates.data()),
+            MB_SUCCESS);
+  return coordinates;
+}
+
+static size_t count_obb_roots(Interface* mbi) {
+  Tag tag;
+  if (mbi->tag_get_handle("OBB_ROOT", tag) != MB_SUCCESS) return 0;
+  Range tagged_sets;
+  EXPECT_EQ(mbi->get_entities_by_type_and_tag(0, MBENTITYSET, &tag, NULL, 1,
+                                              tagged_sets),
+            MB_SUCCESS);
+  return tagged_sets.size();
+}
+
+static double ray_distance(DagMC& dagmc) {
+  double origin[3] = {0.0, 0.0, 0.0};
+  double direction[3] = {0.0, 0.0, 1.0};
+  EntityHandle next_surface;
+  double distance = 0.0;
+  EXPECT_EQ(dagmc.ray_fire(dagmc.entity_by_index(3, 1), origin, direction,
+                           next_surface, distance),
+            MB_SUCCESS);
+  return distance;
+}
 
 class DagmcSimpleTest : public ::testing::Test {
  protected:
@@ -106,6 +151,157 @@ TEST_F(DagmcSimpleTest, dagmc_load_file_dagmc_internal_build_obb) {
   EXPECT_EQ(rval, MB_SUCCESS);
   rval = dagmc->init_OBBTree();
   EXPECT_EQ(rval, MB_SUCCESS);
+}
+
+TEST_F(DagmcSimpleTest, dagmc_length_multiplier) {
+  DagMC baseline;
+  ASSERT_EQ(baseline.load_file(input_file), MB_SUCCESS);
+  EXPECT_THROW(baseline.set_length_multiplier(2.0), std::logic_error);
+  std::vector<double> baseline_coords = geometry_coordinates(baseline);
+  ASSERT_FALSE(baseline_coords.empty());
+  ASSERT_EQ(baseline.init_OBBTree(), MB_SUCCESS);
+
+  const double scales[] = {1.0, 0.01, 2.5, 100.0};
+  for (double scale : scales) {
+    DagMC scaled;
+    scaled.set_length_multiplier(scale);
+    ASSERT_EQ(scaled.load_file(input_file), MB_SUCCESS);
+
+    std::vector<double> scaled_coords = geometry_coordinates(scaled);
+    ASSERT_EQ(scaled_coords.size(), baseline_coords.size());
+    for (size_t i = 0; i < baseline_coords.size(); ++i)
+      EXPECT_NEAR(scaled_coords[i], baseline_coords[i] * scale, 1e-10);
+    EXPECT_DOUBLE_EQ(scaled.faceting_tolerance(),
+                     baseline.faceting_tolerance() * scale);
+
+    ASSERT_EQ(scaled.init_OBBTree(), MB_SUCCESS);
+    EXPECT_NEAR(ray_distance(scaled), 5.0 * scale, 1e-8);
+  }
+}
+
+TEST_F(DagmcSimpleTest, dagmc_length_multiplier_existing_contents) {
+  const char scaled_input[] = "scaling_test.h5m";
+
+  DagMC baseline;
+  ASSERT_EQ(baseline.load_file(input_file), MB_SUCCESS);
+  std::vector<double> baseline_coords = geometry_coordinates(baseline);
+  ASSERT_EQ(baseline.init_OBBTree(), MB_SUCCESS);
+  ASSERT_EQ(baseline.write_mesh(scaled_input, sizeof(scaled_input) - 1),
+            MB_SUCCESS);
+
+  std::shared_ptr<Interface> mbi = std::make_shared<Core>();
+  ASSERT_EQ(mbi->load_file(scaled_input), MB_SUCCESS);
+  const double unrelated_coords[3] = {17.0, -23.0, 41.0};
+  EntityHandle unrelated_vertex;
+  ASSERT_EQ(mbi->create_vertex(unrelated_coords, unrelated_vertex), MB_SUCCESS);
+
+  Tag resabs_tag;
+  ASSERT_EQ(mbi->tag_get_handle("GEOMETRY_RESABS", 1, MB_TYPE_DOUBLE,
+                                resabs_tag, MB_TAG_SPARSE | MB_TAG_CREAT),
+            MB_SUCCESS);
+  const EntityHandle root = 0;
+  double root_resabs = 0.125;
+  ASSERT_EQ(mbi->tag_set_data(resabs_tag, &root, 1, &root_resabs), MB_SUCCESS);
+  EntityHandle unrelated_set;
+  ASSERT_EQ(mbi->create_meshset(MESHSET_SET, unrelated_set), MB_SUCCESS);
+  double unrelated_resabs = 9.0;
+  ASSERT_EQ(mbi->tag_set_data(resabs_tag, &unrelated_set, 1, &unrelated_resabs),
+            MB_SUCCESS);
+
+  Tag obb_root_tag;
+  ASSERT_EQ(mbi->tag_get_handle("OBB_ROOT", 1, MB_TYPE_HANDLE, obb_root_tag,
+                                MB_TAG_SPARSE | MB_TAG_CREAT),
+            MB_SUCCESS);
+  EntityHandle unrelated_obb_set, unrelated_obb_root;
+  ASSERT_EQ(mbi->create_meshset(MESHSET_SET, unrelated_obb_set), MB_SUCCESS);
+  ASSERT_EQ(mbi->create_meshset(MESHSET_SET, unrelated_obb_root), MB_SUCCESS);
+  ASSERT_EQ(mbi->tag_set_data(obb_root_tag, &unrelated_obb_set, 1,
+                              &unrelated_obb_root),
+            MB_SUCCESS);
+
+  DagMC scaled(mbi);
+  scaled.set_length_multiplier(0.4);
+  ASSERT_EQ(scaled.load_existing_contents(), MB_SUCCESS);
+  EXPECT_EQ(count_obb_roots(mbi.get()), 1u);
+  EntityHandle current_obb_root;
+  EXPECT_EQ(
+      mbi->tag_get_data(obb_root_tag, &unrelated_obb_set, 1, &current_obb_root),
+      MB_SUCCESS);
+  EXPECT_EQ(current_obb_root, unrelated_obb_root);
+
+  double current_root_resabs, current_unrelated_resabs;
+  EXPECT_EQ(mbi->tag_get_data(resabs_tag, &root, 1, &current_root_resabs),
+            MB_SUCCESS);
+  EXPECT_EQ(mbi->tag_get_data(resabs_tag, &unrelated_set, 1,
+                              &current_unrelated_resabs),
+            MB_SUCCESS);
+  EXPECT_DOUBLE_EQ(current_root_resabs, root_resabs * 0.4);
+  EXPECT_DOUBLE_EQ(current_unrelated_resabs, unrelated_resabs);
+  EXPECT_DOUBLE_EQ(scaled.faceting_tolerance(),
+                   baseline.faceting_tolerance() * 0.4);
+
+  std::vector<double> scaled_coords = geometry_coordinates(scaled);
+  ASSERT_EQ(scaled_coords.size(), baseline_coords.size());
+  for (size_t i = 0; i < baseline_coords.size(); ++i)
+    EXPECT_NEAR(scaled_coords[i], baseline_coords[i] * 0.4, 1e-10);
+
+  double current_unrelated_coords[3];
+  ASSERT_EQ(mbi->get_coords(&unrelated_vertex, 1, current_unrelated_coords),
+            MB_SUCCESS);
+  for (int i = 0; i < 3; ++i)
+    EXPECT_DOUBLE_EQ(current_unrelated_coords[i], unrelated_coords[i]);
+
+  EXPECT_EQ(scaled.load_existing_contents(), MB_FAILURE);
+  EXPECT_EQ(geometry_coordinates(scaled), scaled_coords);
+  EXPECT_THROW(scaled.set_length_multiplier(2.0), std::logic_error);
+
+  ASSERT_EQ(scaled.init_OBBTree(), MB_SUCCESS);
+  EXPECT_NEAR(ray_distance(scaled), 2.0, 1e-8);
+  remove(scaled_input);
+}
+
+TEST_F(DagmcSimpleTest, dagmc_length_multiplier_failed_load) {
+  std::shared_ptr<Interface> mbi = std::make_shared<Core>();
+  ASSERT_EQ(mbi->load_file(input_file), MB_SUCCESS);
+
+  DagMC baseline(mbi);
+  ASSERT_EQ(baseline.load_existing_contents(), MB_SUCCESS);
+  std::vector<double> baseline_coords = geometry_coordinates(baseline);
+
+  Range surfaces;
+  ASSERT_EQ(baseline.geom_tool()->get_gsets_by_dimension(2, surfaces),
+            MB_SUCCESS);
+  ASSERT_FALSE(surfaces.empty());
+  Tag obb_root_tag;
+  ASSERT_EQ(mbi->tag_get_handle("OBB_ROOT", 1, MB_TYPE_HANDLE, obb_root_tag,
+                                MB_TAG_SPARSE | MB_TAG_CREAT),
+            MB_SUCCESS);
+  Range vertices = geometry_vertices(baseline);
+  ASSERT_FALSE(vertices.empty());
+  EntityHandle invalid_root = vertices.front();
+  ASSERT_EQ(
+      mbi->tag_set_data(obb_root_tag, &surfaces.front(), 1, &invalid_root),
+      MB_SUCCESS);
+
+  DagMC scaled(mbi);
+  scaled.set_length_multiplier(2.0);
+  EXPECT_NE(scaled.load_existing_contents(), MB_SUCCESS);
+  EXPECT_EQ(geometry_coordinates(baseline), baseline_coords);
+  EXPECT_THROW(scaled.set_length_multiplier(3.0), std::logic_error);
+  EXPECT_EQ(scaled.load_existing_contents(), MB_FAILURE);
+}
+
+TEST_F(DagmcSimpleTest, dagmc_length_multiplier_validation) {
+  DagMC dagmc;
+  EXPECT_DOUBLE_EQ(dagmc.length_multiplier(), 1.0);
+  EXPECT_THROW(dagmc.set_length_multiplier(0.0), std::invalid_argument);
+  EXPECT_THROW(dagmc.set_length_multiplier(-1.0), std::invalid_argument);
+  EXPECT_THROW(
+      dagmc.set_length_multiplier(std::numeric_limits<double>::quiet_NaN()),
+      std::invalid_argument);
+  EXPECT_THROW(
+      dagmc.set_length_multiplier(std::numeric_limits<double>::infinity()),
+      std::invalid_argument);
 }
 
 TEST_F(DagmcSimpleTest, dagmc_test_obb_retreval) {


### PR DESCRIPTION
Adds an optional positive, finite length multiplier that is applied when DagMC geometry is loaded. The default is 1.0 and preserves existing behavior.

Only vertices referenced by DAGMC surface triangles are scaled. Shared vertices are updated once, unrelated MOAB content is preserved, source-unit length metadata is scaled, and stale geometry OBB trees are removed before coordinates change. Repeated nonidentity loading cannot compound the transformation.

Validation includes scale-up, scale-down, noninteger and invalid factors, shared and unrelated vertices, scoped OBB removal, metadata, repeated loading, failed loading, and ray navigation. A clean GCC 14.2 build against MOAB 5.5.1 passed all 11 registered CTest targets and the changed files pass the repository formatting check.

Fork CI passes Linux Build/Test and Housekeeping Checks. The macOS job stops during dependency configuration because Homebrew HDF5 cannot locate ZLIB_LIBRARY, before DAGMC source is compiled. The changelog job stops in actions/checkout@v3 on its Alpine container under the runner's forced Node 24 runtime.

Based on `svalinn/DAGMC@b1246725`. The corresponding PyDAGMC and OpenMC branches use this API.